### PR TITLE
Add parent group for customize and byte-compile warning

### DIFF
--- a/mote-mode.el
+++ b/mote-mode.el
@@ -16,7 +16,8 @@
 (require 'ruby-mode)
 
 (defgroup mote nil
-  "Mote mode customization group")
+  "Mote mode customization group"
+  :group 'ruby)
 
 (defun mote-highlight-ruby (limit)
   "Highlight a Ruby expression."


### PR DESCRIPTION
There is following byte-compile warning.

```
mote-mode.el:18:1:Warning: defgroup for `mote' fails to specify containing
    group
```
